### PR TITLE
fix: add "python.analysis.extraPaths" to default settings

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -14,6 +14,8 @@
 	"settings": {
 		// Automatically add common search paths like 'src'?
 		"python.analysis.autoSearchPaths": true,
+		// Additional import search resolution paths
+		"python.analysis.extraPaths": [],
 		// Path to directory containing custom type stub files.
 		"python.analysis.stubPath": "./typings",
 		// "openFilesOnly" or "workspace"


### PR DESCRIPTION
Any specific reason why was this omitted?