### PR TITLE
refactor: remove redundant $sublime_packages_dir variable

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -17,7 +17,7 @@
 		"python.analysis.extraPaths": [
 			// For Sublime Text plugin development
 			"$sublime_py_files_dir",
-			"$sublime_packages_dir",
+			"$packages",
 		],
 		// Path to directory containing custom type stub files.
 		"python.analysis.stubPath": "./typings",

--- a/plugin.py
+++ b/plugin.py
@@ -24,5 +24,4 @@ class LspPyrightPlugin(NpmClientHandler):
     def additional_variables(cls) -> Optional[Dict[str, str]]:
         variables = {}
         variables["sublime_py_files_dir"] = os.path.dirname(sublime.__file__)
-        variables["sublime_packages_dir"] = sublime.packages_path()
         return variables


### PR DESCRIPTION
It's the same with `window.extract_variables()['packages']`.
I.e., `$packages` can be used instead.

@rwols As per suggestion in https://github.com/sublimelsp/LSP-pyright/issues/3#issue-669065719, I assume `LSP-pyls` is interested in this too.