### PR TITLE
Add ST3 compatibility

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -3,6 +3,9 @@
 	"languages": [
 		{
 			"languageId": "python",
+			// ST3
+			"scopes": ["source.python"],
+			"syntaxes": ["Packages/Python/Python.sublime-syntax"],
 		},
 	],
 	// @see https://github.com/microsoft/pyright/blob/master/docs/configuration.md


### PR DESCRIPTION
With latest LSP3 release we'll be able to use the same branch for both
ST3 and ST4. Both dotted settings and parsing variables are supported.

Unfortunately the schema validation will mark the ST3 properties as
deprecated.