### PR TITLE
fix: update python.analysis.logLevel schema and setting

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -38,7 +38,7 @@
 			// "reportUnusedVariable": "information",
 		},
 		// Specifies the level of logging for the Output panel
-		"python.analysis.logLevel": "info",
+		"python.analysis.logLevel": "information",
 		// Defines the default rule set for type checking.
 		"python.analysis.typeCheckingMode": "basic",
 		// Paths to look for typeshed modules.

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -585,7 +585,7 @@
                     },
                     "python.analysis.logLevel": {
                       "type": "string",
-                      "default": "info",
+                      "default": "information",
                       "description": "Specifies the level of logging for the Output panel",
                       "enum": [
                         "error",


### PR DESCRIPTION
Follows a fix in pyright: https://github.com/microsoft/pyright/commit/c07ca7057336e232eb2103e09a2c819f9fc454fa