### PR TITLE
fix: enable useful diagnostics by default

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -29,13 +29,13 @@
 		// Allows a user to override the severity levels for individual diagnostics.
 		// @see https://github.com/microsoft/pyright/blob/master/docs/configuration.md#type-check-diagnostics-settings
 		"python.analysis.diagnosticSeverityOverrides": {
-			// "reportImplicitStringConcatenation": "warning",
-			// "reportUnboundVariable": "warning",
-			// "reportDuplicateImport ": "warning",
-			// "reportUnusedClass": "information",
-			// "reportUnusedFunction": "information",
-			// "reportUnusedImport": "information",
-			// "reportUnusedVariable": "information",
+			"reportImplicitStringConcatenation": "warning",
+			"reportUnboundVariable": "warning",
+			"reportDuplicateImport ": "warning",
+			"reportUnusedClass": "information",
+			"reportUnusedFunction": "information",
+			"reportUnusedImport": "information",
+			"reportUnusedVariable": "information",
 		},
 		// Specifies the level of logging for the Output panel
 		"python.analysis.logLevel": "information",


### PR DESCRIPTION
I'm not sure it's the right thing to do but created PR to discuss it.

I think that we should have those diagnostics enabled by default (I've seen that Pylance reports unused imports at least) as they are rather useful.

The problem with setting those is that there is also a `python.analysis.typeCheckingMode` option that can be set to either `basic` or `strict` (the default being `basic`) and if someone would set it to `strict` then having `python.analysis.diagnosticSeverityOverrides` options explicitly set would override more strict values that `strict` uses. I wonder if we are fine with that. Or are we fine with current defaults and expect the user to enable those if he wants?