### PR TITLE
Update lockfile

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "pyright": {
-      "version": "1.1.112",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.112.tgz",
-      "integrity": "sha512-/pwzJWmGo3s7gETYq9CUcPP5F4ZxFBe9u8sQpEJDHD//YFi97EQjhBkOT4M6sNEKpG8u/nyoVRK9ZlGFBHZtcQ=="
+      "version": "1.1.113",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.113.tgz",
+      "integrity": "sha512-VcitW5t5lG1KY0w8xY/ubMhFZZ2lfXJvhBW4TfTwy067R4WtXKSa23br4to1pdRA1rwpxOREgxVTnOWmf3YkYg=="
     }
   }
 }


### PR DESCRIPTION
The last update missed the lockfile update so `npm ci` would fail to install dependencies.