### PR TITLE
feat: enable pyright in raw buffers and ST resource files

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -10,6 +10,14 @@
 	],
 	// ST4
 	"selector": "source.python",
+    "schemes": [
+        // regular files
+        "file",
+        // in-memory buffers
+        "buffer",
+        // files in .sublime-package archives
+        "res"
+    ],
 	// @see https://github.com/microsoft/pyright/blob/master/docs/configuration.md
 	"initializationOptions": {
 		// ...


### PR DESCRIPTION
This language server seems to work on raw buffers. Although it's doing something weird with diagnostic publishing. Depends on https://github.com/sublimelsp/LSP/pull/1758