### PR TITLE
Allow python.venv in the project settings

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -71,5 +71,6 @@
 		"python.pythonPath": "python",
 		// Path to folder with a list of Virtual Environments.
 		"python.venvPath": "",
+		"python.venv": "",
 	},
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -711,6 +711,11 @@
                       "type": "string",
                       "default": "",
                       "description": "Path to folder with a list of Virtual Environments."
+                    },
+                    "python.venv": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Name of virtual environment subdirectory within venvPath."
                     }
                   }
                 }


### PR DESCRIPTION
This PR is more a question of why the `venv` option is only allowed in the `pyrightconfig.json`
Are there any technical limitations?