### PR TITLE
chore: update link to pyright, change branch from master to main

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -5,12 +5,12 @@
 		"buffer", // in-memory buffers
 		"res", // files in .sublime-package archives
 	],
-	// @see https://github.com/microsoft/pyright/blob/master/docs/configuration.md
+	// @see https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 	"initializationOptions": {
 		// ...
 	},
-	// @see https://github.com/microsoft/pyright/blob/master/docs/settings.md
-	// @see https://github.com/microsoft/pyright/blob/master/packages/vscode-pyright/package.json
+	// @see https://github.com/microsoft/pyright/blob/main/docs/settings.md
+	// @see https://github.com/microsoft/pyright/blob/main/packages/vscode-pyright/package.json
 	"settings": {
 		// Use a predefined setup from this plugin, valid values are:
 		// - "": An empty string does nothing.
@@ -32,7 +32,7 @@
 		// "openFilesOnly" or "workspace"
 		"python.analysis.diagnosticMode": "openFilesOnly",
 		// Allows a user to override the severity levels for individual diagnostics.
-		// @see https://github.com/microsoft/pyright/blob/master/docs/configuration.md#type-check-diagnostics-settings
+		// @see https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings
 		"python.analysis.diagnosticSeverityOverrides": {
 			"reportDuplicateImport ": "warning",
 			"reportImplicitStringConcatenation": "warning",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here are some ways to configure the package and the language server.
   }
   ```
 
-- Through a `pyrightconfig.json` configuration file (check [settings documentation](https://github.com/microsoft/pyright/blob/master/docs/configuration.md))
+- Through a `pyrightconfig.json` configuration file (check [settings documentation](https://github.com/microsoft/pyright/blob/main/docs/configuration.md))
 
 ### Provided Command Palette commands
 
@@ -67,4 +67,4 @@ For example, if you have created a virtual environment inside the directory `.ve
 
 Note that the `venv` option is only supported in the `pyrightconfig.json` file. The `venvPath` option can also be specified in your .sublime-project, in case you don't want to hard-code a system-specific path in a shared project.
 
-Please see [Pyright Documentation](https://github.com/microsoft/pyright/blob/master/docs/configuration.md) for more options.
+Please see [Pyright Documentation](https://github.com/microsoft/pyright/blob/main/docs/configuration.md) for more options.


### PR DESCRIPTION
Because the branch master of `pyright` was renamed to main.
![2021-12-24-215948_1828x773_scrot](https://user-images.githubusercontent.com/3500109/147358444-3d99bb9f-d585-4cdd-9b8f-cf1caeab0c63.png)
