### PR TITLE
fix: check if venv binary is valid before returning

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -179,7 +179,8 @@ class LspPyrightPlugin(NpmClientHandler):
         for file in os.listdir(workspace_folder):
             maybe_venv_path = os.path.join(workspace_folder, file)
             if os.path.isfile(os.path.join(maybe_venv_path, "pyvenv.cfg")):
-                # found a venv
-                return binary_from_python_path(maybe_venv_path)
+                binary = binary_from_python_path(maybe_venv_path)
+                if binary is not None:
+                    return binary  # found a venv
 
         return None


### PR DESCRIPTION
This commit changes the virtual environment (venv) detection logic to check if the venv binary is a valid file before returning.

This fixes a bug where LSP-pyright would detect and use a broken venv even though a valid one existed (I had a project with a broken "bak.venv" directory that contained a "pyvenv.cfg" and a broken python symlink).