### PR TITLE
feat: use py version of developed plugin if "dev_environment" is "sublime_text"

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -11,7 +11,7 @@
 		// Use a predefined setup from this plugin, valid values are:
 		// - "": An empty string does nothing.
 		// - "sublime_text": Suitable for people who are developing ST Python plugins.
-		//                   The Python version which this plugin runs on will be used.
+		//                   The Python version which the developed plugin runs on will be used.
 		//                   `sys.path` from plugin_host will be added into "python.analysis.extraPaths"
 		//                   so ST package dependecies can be resolved by the LSP server.
 		// - "sublime_text_33": Similar to "sublime_text" but Python 3.3 forced.

--- a/plugin.py
+++ b/plugin.py
@@ -6,11 +6,14 @@ import sys
 
 import sublime
 from LSP.plugin import ClientConfig, DottedDict, WorkspaceFolder
-from LSP.plugin.core.typing import Any, Callable, List, Optional, Tuple, cast
+from LSP.plugin.core.typing import Any, Callable, List, Optional, Tuple
 from lsp_utils import NpmClientHandler
 from sublime_lib import ResourcePath
 
-if int(sublime.version()) >= 4070:
+SUBLIME_VERSION = int(sublime.version())
+SUBLIME_PACKAGES_PATH = sublime.packages_path()
+
+if SUBLIME_VERSION >= 4070:
     from LSP.plugin import MarkdownLangMap
 
 
@@ -37,11 +40,25 @@ class LspPyrightPlugin(NpmClientHandler):
         dev_environment = self.get_dev_environment(settings)
 
         if dev_environment in ("sublime_text", "sublime_text_33", "sublime_text_38"):
-            if dev_environment == "sublime_text":
-                # the Python version this plugin runs on
-                py_ver = cast(Tuple[int, int], tuple(sys.version_info[:2]))
-            else:
-                py_ver = (3, 8) if dev_environment == "sublime_text_38" else (3, 3)
+            py_ver = (3, 3)
+            if dev_environment == "sublime_text" and SUBLIME_VERSION >= 4050:
+                session = self.weaksession()
+                if session:
+                    workspace_folders = session.get_workspace_folders()
+                    if workspace_folders:
+                        if workspace_folders[0].path == os.path.join(SUBLIME_PACKAGES_PATH, "User"):
+                            py_ver = (3, 8)
+                        else:
+                            python_version_file = os.path.join(workspace_folders[0].path, ".python-version")
+                            if os.path.isfile(python_version_file):
+                                try:
+                                    with open(python_version_file, "r") as file:
+                                        if file.read().strip() == "3.8":
+                                            py_ver = (3, 8)
+                                except OSError:
+                                    pass
+            elif dev_environment == "sublime_text_38":
+                py_ver = (3, 8)
 
             # add package dependencies into "python.analysis.extraPaths"
             extraPaths = settings.get("python.analysis.extraPaths") or []  # type: List[str]
@@ -106,12 +123,12 @@ class LspPyrightPlugin(NpmClientHandler):
 
         # move the "Packages/" to the last
         # @see https://github.com/sublimelsp/LSP-pyright/pull/26#discussion_r520747708
-        packages_path = sublime.packages_path()
-        dep_dirs.remove(packages_path)
-        dep_dirs.append(packages_path)
+        dep_dirs.remove(SUBLIME_PACKAGES_PATH)
+        dep_dirs.append(SUBLIME_PACKAGES_PATH)
 
-        # sublime stubs - add as first
-        dep_dirs.insert(0, os.path.join(self.package_storage(), "resources", "typings", "sublime_text"))
+        if py_ver == (3, 3):
+            # sublime stubs - add as first
+            dep_dirs.insert(0, os.path.join(self.package_storage(), "resources", "typings", "sublime_text"))
 
         return [path for path in dep_dirs if os.path.isdir(path)]
 


### PR DESCRIPTION
Apparently "this" refers to "LSP-pyright" in

https://github.com/sublimelsp/LSP-pyright/blob/56ddea390391d0f9f69e1cc0532f1da7e834ed9f/LSP-pyright.sublime-settings#L14

So if you set "pyright.dev_environment" to "sublime_text", currently it will use the Python version under which LSP-pyright runs in the plugin host, i.e. always Python 3.3. In other words, "sublime_text" is just an alias for "sublime_text_33".

Instead of using `sys.version_info`, you could just hardcode `py_ver = (3, 3)` in
https://github.com/sublimelsp/LSP-pyright/blob/56ddea390391d0f9f69e1cc0532f1da7e834ed9f/plugin.py#L42

But is it useful in any way to use the Python version of LSP-pyright here?

If you want to develop a plugin for ST4 which should run under Python 3.8, then for example this will show an error diagnostic, because `AutoCompleteFlags` is unknown in the py3.3 version of sublime.py (and not contained in your stub files):
```python
from sublime import AutoCompleteFlags
```

So I think it would be better to use the Python version of the developed plugin instead, and not the Python version of LSP-pyright.

I quickly wrote something to check for a .python-version file in the first workspace folder and set the environment to 3.8 if specified therein.