### PR TITLE
Apply some tweaks to content of hover popups

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -102,7 +102,8 @@ class LspPyrightPlugin(NpmClientHandler):
         content = re.sub("```\n---", "```\n\n---", content)
         # Add markup for some common field name conventions in function docstring
         content = re.sub(
-            r"\n:param[ ]+([\w\\]+):", lambda m: "\n__Param:__ `{}`".format(m.group(1).replace("\\_", "_")), content)
+            r"\n:param[ ]+([\w\\]+):", lambda m: "\n__Param:__ `{}`".format(m.group(1).replace("\\_", "_")), content
+        )
         content = re.sub(r"\n:raises[ ]+(\w+):", r"\n__Raises:__ `\1`", content)
         content = re.sub(r"\n:returns?:", r"\n__Returns:__", content)
         return content

--- a/plugin.py
+++ b/plugin.py
@@ -98,7 +98,6 @@ class LspPyrightPlugin(NpmClientHandler):
                 return
             response.result["documentation"]["value"] = self.patch_markdown_content(documentation["value"])
 
-
     # -------------- #
     # custom methods #
     # -------------- #
@@ -108,9 +107,9 @@ class LspPyrightPlugin(NpmClientHandler):
         content = re.sub("```\n---", "```\n\n---", content)
         # Add markup for some common field name conventions in function docstring
         content = re.sub(
-            r"\n:(\w+)[ ]+([\w\\]+):", lambda m: "\n__{}:__ `{}`".format(
-                m.group(1).title(), m.group(2).replace("\\_", "_")
-            ), content
+            r"\n:(\w+)[ ]+([\w\\]+):",
+            lambda m: "\n__{}:__ `{}`".format(m.group(1).title(), m.group(2).replace("\\_", "_")),
+            content,
         )
         content = re.sub(r"\n:returns?:", r"\n__Returns:__", content)
         content = re.sub(r"\n:rtype:", r"\n__Returntype:__", content)

--- a/plugin.py
+++ b/plugin.py
@@ -92,6 +92,12 @@ class LspPyrightPlugin(NpmClientHandler):
             if not isinstance(contents, dict) or not contents.get("kind") == "markdown":
                 return
             response.result["contents"]["value"] = self.patch_markdown_content(contents["value"])
+        elif method == "completionItem/resolve" and isinstance(response.result, dict):
+            documentation = response.result.get("documentation")
+            if not isinstance(documentation, dict) or not documentation.get("kind") == "markdown":
+                return
+            response.result["documentation"]["value"] = self.patch_markdown_content(documentation["value"])
+
 
     # -------------- #
     # custom methods #

--- a/plugin.py
+++ b/plugin.py
@@ -102,10 +102,12 @@ class LspPyrightPlugin(NpmClientHandler):
         content = re.sub("```\n---", "```\n\n---", content)
         # Add markup for some common field name conventions in function docstring
         content = re.sub(
-            r"\n:param[ ]+([\w\\]+):", lambda m: "\n__Param:__ `{}`".format(m.group(1).replace("\\_", "_")), content
+            r"\n:(\w+)[ ]+([\w\\]+):", lambda m: "\n__{}:__ `{}`".format(
+                m.group(1).title(), m.group(2).replace("\\_", "_")
+            ), content
         )
-        content = re.sub(r"\n:raises[ ]+(\w+):", r"\n__Raises:__ `\1`", content)
         content = re.sub(r"\n:returns?:", r"\n__Returns:__", content)
+        content = re.sub(r"\n:rtype:", r"\n__Returntype:__", content)
         return content
 
     def detect_st_py_ver(self, dev_environment: str) -> Tuple[int, int]:


### PR DESCRIPTION
Here is a suggestion with some enhancement for pyright's hover popups:

1. Fix horizontal rule after fenced code block accidentally being rendered as setext heading (this seems to be a bug in mdpopups or in one of its dependencies)
2. Improve rendering for some common reStructuredText field names in docstrings (ideally pyright should parse the docstrings itself and should have this built-in...)

__Before:__

![before](https://user-images.githubusercontent.com/6579999/208600682-4f863919-075b-4549-8f09-32dcd2e1fe75.png)

__After:__

![after](https://user-images.githubusercontent.com/6579999/208600701-13d68e67-ea6d-4157-b9ef-4651e59e915f.png)