### PR TITLE
fix: remove stray whitespace in settings and adjust schema

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -30,7 +30,7 @@
 		// Allows a user to override the severity levels for individual diagnostics.
 		// @see https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings
 		"python.analysis.diagnosticSeverityOverrides": {
-			"reportDuplicateImport ": "warning",
+			"reportDuplicateImport": "warning",
 			"reportImplicitStringConcatenation": "warning",
 			"reportMissingParameterType": "none",
 			"reportUnboundVariable": "warning",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -75,6 +75,7 @@
                     "python.analysis.diagnosticSeverityOverrides": {
                       "default": {},
                       "description": "Allows a user to override the severity levels for individual diagnostics.",
+                      "additionalProperties": false,
                       "properties": {
                         "reportAssertAlwaysTrue": {
                           "default": "warning",


### PR DESCRIPTION
This seems like an error in the default settings.