### PR TITLE
fix: popup docstring rendering for **kwargs

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -108,8 +108,11 @@ class LspPyrightPlugin(NpmClientHandler):
         content = re.sub("```\n---", "```\n\n---", content)
         # Add markup for some common field name conventions in function docstring
         content = re.sub(
-            r"\n:(\w+)[ ]+([\w\\]+):",
-            lambda m: "\n__{}:__ `{}`".format(m.group(1).title(), m.group(2).replace("\\_", "_")),
+            r"\n:(\w+)[ ]+([\w\\*]+):",
+            lambda m: "\n__{field}:__ `{name}`".format(
+                field=m.group(1).title(),
+                name=m.group(2).replace("\\_", "_").replace("\\*", "*"),
+            ),
             content,
         )
         content = re.sub(r"\n:returns?:", r"\n__Returns:__", content)


### PR DESCRIPTION
![Snipaste_2023-03-07_15-07-01](https://user-images.githubusercontent.com/6594915/223353536-ab30fae2-f741-4e47-ac9b-71ab4b167c6d.png)

Maybe it's a wrong docstring but supporting this wouldn't hurt.