### PR TITLE
fix: syntax highlighting of type groups and function signatures

### DIFF
--- a/syntaxes/pyright.sublime-syntax
+++ b/syntaxes/pyright.sublime-syntax
@@ -43,18 +43,77 @@ contexts:
 ###[ PYRIGHT TYPE ANNOTATIONS ]###############################################
 
   lsp-type-annotations:
-    - match: (?=\(\()
-      push: lsp-union-function
+    - include: lsp-type-parens
     - include: lsp-type-signatures
 
-  # union of (function) or (method)
-  lsp-union-function:
-    - match: \((?=\()
-      scope: punctuation.section.parameters.begin.python
-      push: function-parameter-list
-    - match: \|
-      scope: keyword.operator.arithmetic.python
-    - include: eol-pop
+  lsp-type-parens:
+    - match: (?=\()
+      branch_point: lsp-type-parens
+      branch:
+        - lsp-type-function
+        - lsp-type-group
+
+  lsp-type-function:
+    - match: \(
+      scope: meta.function.parameters.python punctuation.section.parameters.begin.python
+      set: lsp-type-function-parameter-list
+    - include: immediately-pop
+
+  lsp-type-function-parameter-list:
+    - meta_content_scope: meta.function.parameters.python
+    - match: \)
+      scope: meta.function.parameters.python punctuation.section.parameters.end.python
+      set: lsp-type-function-return-type
+    - match: '{{colon}}'
+      scope: punctuation.separator.annotation.parameter.python
+      set: lsp-type-function-parameter-annotation
+    - match: '{{identifier}}(?={{colon}})'
+      scope: variable.parameter.python
+    - include: function-parameter-annotation
+    - include: lsp-type-parameter-common
+
+  lsp-type-function-parameter-annotation:
+    - meta_scope: meta.function.parameters.annotation.python
+    - match: (?=[,)=])
+      set: lsp-type-function-parameter-list
+    - match: None\b
+      scope: constant.language.null.python
+    - include: expression-in-a-group
+
+  lsp-type-parameter-common:
+    - match: ','
+      scope: punctuation.separator.parameters.python
+      push: allow-unpack-operators
+    - match: /
+      scope: storage.modifier.positional-args-only.python
+      push: function-parameter-expect-comma
+    - match: '{{assignment_operator}}'
+      scope: keyword.operator.assignment.python
+      set: function-parameter-default-value
+    - include: line-continuations
+    - include: illegal-assignment-expressions
+
+  lsp-type-function-return-type:
+    - meta_content_scope: meta.function.python
+    - match: ->
+      scope: meta.function.annotation.return.python punctuation.separator.annotation.return.python
+      set: function-return-type
+    - match: (?=\S)
+      fail: lsp-type-parens
+
+  lsp-type-group:
+    - match: \(
+      scope: punctuation.section.group.begin.python
+      set: lsp-type-group-body
+    - include: immediately-pop
+
+  lsp-type-group-body:
+    - meta_scope: meta.group.python
+    - match: \)
+      scope: punctuation.section.group.end.python
+      set: after-expression
+    - include: lsp-type-annotations
+    - include: expression-in-a-group
 
   lsp-type-signatures:
     - match: (?={{path}}\s*\[)
@@ -72,9 +131,7 @@ contexts:
     - match: \]
       scope: punctuation.section.sequence.end.python
       set: after-expression
-    - match: (?=\()
-      push: function-parameter-list
-    - include: lsp-type-signatures
+    - include: lsp-type-annotations
     - include: expression-in-a-group
 
 ###[ PYTHON CLASS DEFINITION OVERRIDES ]######################################
@@ -99,22 +156,12 @@ contexts:
     - meta_content_scope: meta.class.parameters.python
     - match: \)
       scope: meta.class.parameters.python punctuation.section.parameters.end.python
-      pop: 1
-    - match: ','
-      scope: punctuation.separator.parameters.python
-      push: allow-unpack-operators
-    - match: /
-      scope: storage.modifier.positional-args-only.python
-      push: function-parameter-expect-comma
-    - match: '{{assignment_operator}}'
-      scope: keyword.operator.assignment.python
-      set: class-definition-parameter-default-value
+      set: after-expression
     - match: '{{colon}}'
       scope: punctuation.separator.annotation.parameter.python
       set: class-definition-parameter-annotation
     - include: parameter-names
-    - include: line-continuations
-    - include: illegal-assignment-expressions
+    - include: lsp-type-parameter-common
 
   class-definition-parameter-annotation:
     - meta_scope: meta.class.parameters.annotation.python

--- a/syntaxes/syntax_test.pyright-syntax-test
+++ b/syntaxes/syntax_test.pyright-syntax-test
@@ -124,3 +124,59 @@ NamedTemporaryFile: Overload[() -> None, () -> None, (mode: Literal['r', 'w'] = 
 #                                                                             ^ keyword.operator.assignment
 #                                                                                    ^^^^ variable.parameter
 #                                                                                              ^ keyword.operator.assignment
+
+def foo(callback: ((arg: _T@foo) -> bool) | ((_T@foo) -> int) | None = None) -> (_T@foo | None)
+#       ^^^^^^^^ meta.function.parameters.python
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.annotation.python
+#                 ^ meta.group.python - meta.group meta.function
+#                  ^^^^ meta.group.python meta.function.parameters.python
+#                      ^^^^^^^^ meta.group.python meta.function.parameters.annotation.python
+#                              ^ meta.group.python meta.function.parameters.python
+#                               ^ meta.group.python meta.function.python
+#                                ^^^^^^^ meta.group.python meta.function.annotation.return.python
+#                                       ^ meta.group.python -  meta.group meta.function
+#                                           ^ meta.group.python - meta.group meta.function
+#                                            ^^^^^^^^ meta.group.python meta.function.parameters.python
+#                                                    ^ meta.group.python meta.function.python
+#                                                     ^^^^^^ meta.group.python meta.function.annotation.return.python
+#                                                           ^ meta.group.python - meta.group meta.function
+#                                                                    ^^^^^^ meta.function.parameters.default-value.python
+#                                                                          ^ meta.function.parameters.python
+#                                                                           ^ meta.function.python
+#                                                                            ^^^ meta.function.annotation.return.python - meta.group
+#                                                                               ^^^^^^^^^^^^^^^ meta.function.annotation.return.python meta.group.python
+#               ^ punctuation.separator.annotation.parameter.python
+#                 ^ punctuation.section.group.begin.python
+#                  ^ punctuation.section.parameters.begin.python
+#                   ^^^ variable.parameter.python
+#                      ^ punctuation.separator.annotation.parameter.python
+#                        ^^ meta.path.python meta.generic-name.python
+#                          ^ keyword.operator.arithmetic.python
+#                           ^^^ meta.path.python meta.generic-name.python
+#                              ^ punctuation.section.parameters.end.python
+#                                ^^ punctuation.separator.annotation.return.python
+#                                   ^^^^ meta.path.python support.type.python
+#                                       ^ punctuation.section.group.end.python
+#                                         ^ keyword.operator.arithmetic.python
+#                                           ^ punctuation.section.group.begin.python
+#                                            ^ punctuation.section.parameters.begin.python
+#                                             ^^ meta.path.python meta.generic-name.python
+#                                               ^ keyword.operator.arithmetic.python
+#                                                ^^^ meta.path.python meta.generic-name.python
+#                                                   ^ punctuation.section.parameters.end.python
+#                                                     ^^ punctuation.separator.annotation.return.python
+#                                                        ^^^ meta.path.python support.type.python
+#                                                           ^ punctuation.section.group.end.python
+#                                                             ^ keyword.operator.arithmetic.python
+#                                                               ^^^^ constant.language.null.python
+#                                                                    ^ keyword.operator.assignment.python
+#                                                                      ^^^^ constant.language.null.python
+#                                                                          ^ punctuation.section.parameters.end.python
+#                                                                            ^^ punctuation.separator.annotation.return.python
+#                                                                               ^ punctuation.section.group.begin.python
+#                                                                                ^^ meta.path.python meta.generic-name.python
+#                                                                                  ^ keyword.operator.arithmetic.python
+#                                                                                   ^^^ meta.path.python meta.generic-name.python
+#                                                                                       ^ keyword.operator.arithmetic.python
+#                                                                                         ^^^^ constant.language.null.python
+#                                                                                             ^ punctuation.section.group.end.python


### PR DESCRIPTION
fixes: #233

This commit uses branching to distinguish type groups and function signatures.

A function signature is of the form `(arg: type, ...) -> return-type`