### PR TITLE
chore: adjust syntax to python type hints

### DIFF
--- a/syntaxes/Python.sublime-syntax
+++ b/syntaxes/Python.sublime-syntax
@@ -3,6 +3,7 @@
 name: Python
 scope: source.python.lsp
 version: 2
+
 hidden: true
 
 variables:
@@ -141,6 +142,32 @@ variables:
     | basestring | long | unicode
     # Python 2 types prone to conflicts
     # | buffer | file
+    )\b
+
+  typing_types: |-
+    (?x:
+    # Super-special typing primitives.
+      Annotated | Any | Callable | ClassVar | Concatenate | Final | ForwardRef
+    | Generic | Literal | Optional | ParamSpec | Protocol | Tuple | Type
+    | TypeVar | TypeVarTuple | Union
+    # ABCs (from collections.abc).
+    | AbstractSet | ByteString | Container | ContextManager | Hashable | ItemsView
+    | Iterable | Iterator | KeysView | Mapping | MappingView | MutableMapping
+    | MutableSequence | MutableSet | Sequence | Sized | ValuesView | Awaitable
+    | AsyncIterator | AsyncIterable | Coroutine | Collection | AsyncGenerator
+    | AsyncContextManager
+    # Structural checks, a.k.a. protocols.
+    | Reversible | SupportsAbs | SupportsBytes | SupportsComplex | SupportsFloat
+    | SupportsIndex | SupportsInt | SupportsRound
+    # Concrete collection types.
+    | ChainMap | Counter | Deque | Dict | DefaultDict | List | OrderedDict
+    | Set | FrozenSet | NamedTuple | TypedDict | Generator
+    # Other concrete types.
+    | BinaryIO | IO | Match | Pattern | TextIO
+    # One-off things.
+    | AnyStr | LiteralString | Never | NewType | NoReturn | NotRequired
+    | ParamSpecArgs | ParamSpecKwargs | Required | Self | Text | TypeAlias
+    | TypeGuard | Unpack
     )\b
 
   magic_functions: |-
@@ -305,7 +332,9 @@ contexts:
   comments:
     - match: \#
       scope: punctuation.definition.comment.python
-      push: comment-body
+      push:
+        - comment-body
+        - type-hint
 
   comment-body:
     - meta_scope: comment.line.number-sign.python
@@ -328,6 +357,143 @@ contexts:
       scope: constant.language.shebang.python
     - match: \n
       pop: 1
+
+###[ TYPE HINTS ]#############################################################
+
+  type-hint:
+    # 1st type hint may be of any type
+    - match: (type)(:)
+      captures:
+        1: keyword.other.type.python
+        2: punctuation.separator.type.python
+      set: type-hint-any
+    - include: else-pop
+    - include: eol-pop
+
+  type-hint-any:
+    - meta_scope: meta.type.python
+    - include: type-hint-end
+    - match: ignore\b
+      scope: keyword.other.ignore.python
+      set:
+        - type-hint-type
+        - type-hint-error-list
+    - match: (?=\S)
+      set:
+        - type-hint-ignore
+        - type-hint-begin
+
+  type-hint-ignore:
+    # 2nd type hint may only be a `type: ignore`
+    # As it isn't a real start of a comment `#` is not scoped punctuation.
+    - match: \s*\#\s*((type)(:)\s*(ignore\b))
+      captures:
+        1: meta.type.python
+        2: keyword.other.type.python
+        3: punctuation.separator.type.python
+        4: keyword.other.ignore.python
+      set: type-hint-error-list
+    - include: immediately-pop
+
+  type-hint-type:
+    # 2nd type hint must not be a `type: ignore`
+    # As it isn't a real start of a comment `#` is not scoped punctuation.
+    - match: \s*\#\s*((type)(:)(?!\s*ignore\b))
+      captures:
+        1: meta.type.python
+        2: keyword.other.type.python
+        3: punctuation.separator.type.python
+      set: type-hint-begin
+    - include: immediately-pop
+
+  type-hint-error-list:
+    - meta_content_scope: meta.type.python
+    - match: \[
+      scope: punctuation.section.sequence.begin.python
+      set: type-hint-error-list-body
+    - include: type-hint-end
+
+  type-hint-error-list-body:
+    - meta_scope: meta.type.python meta.sequence.list.errors.python
+    - match: \]
+      scope: punctuation.section.sequence.end.python
+      pop: 1
+    - include: type-hint-end
+    - include: sequence-separators
+    - match: \b[[:alpha:]_-][[:alnum:]_-]+\b
+      scope: constant.other.error-code.python
+
+  type-hint-begin:
+    - meta_content_scope: meta.type.python
+    - match: \(
+      scope: punctuation.section.parameters.begin.python
+      set: type-hint-function-parameter-list-body
+    - match: (?=\S)
+      set: type-hint-body
+
+  type-hint-function-parameter-list-body:
+    - meta_scope: meta.type.function.parameters.python
+    - match: \)
+      scope: punctuation.section.parameters.end.python
+      set: type-hint-function-return-type
+    - include: type-hint-body
+
+  type-hint-function-return-type:
+    - meta_content_scope: meta.type.function.python
+    - match: ->
+      scope: punctuation.separator.return-type.python
+      set: type-hint-function-return-type-body
+    - include: type-hint-end
+
+  type-hint-function-return-type-body:
+    - meta_scope: meta.type.function.return-type.python
+    - include: type-hint-body
+
+  type-hint-body:
+    - meta_scope: meta.type.python
+    - include: type-hint-end
+    - include: type-hint-expressions
+
+  type-hint-end:
+    - match: (?=\s*[\n#])
+      pop: 1
+
+  type-hint-expressions:
+    - include: type-hint-lists
+    - include: type-separators
+    - include: type-constants
+    - include: constants
+    - include: double-quoted-strings
+    - include: single-quoted-strings
+    - include: builtin-exceptions
+    - include: builtin-types
+    - include: qualified-name
+
+  type-hint-lists:
+    - match: \[
+      scope: punctuation.section.brackets.begin.python
+      push: type-hint-list-body
+
+  type-hint-list-body:
+    # As annotations contain normal expressions use a generic `meta.brackets`
+    # for sake of consistent scoping/highlighting.
+    - meta_scope: meta.brackets.python
+    - match: \]
+      scope: punctuation.section.brackets.end.python
+      pop: 1
+    - include: type-hint-body
+
+  type-constants:
+    # Note: Enables `None = None` in type hints.
+    - match: None\b
+      scope: constant.language.null.python
+
+  type-separators:
+    # Note: Scoped as normal arithmetic operator for consistency reasons with
+    #       type-hints in annotations, which share syntax with normal expressions
+    - match: \|
+      scope: keyword.operator.arithmetic.python
+    - include: sequence-separators
 
 ###[ DECORATORS ]#############################################################
 
@@ -654,7 +820,7 @@ contexts:
       scope: keyword.operator.assignment.python
       set: function-parameter-default-value
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.parameter.python
+      scope: punctuation.separator.annotation.python
       set: function-parameter-annotation
     - include: comments
     - include: function-parameter-tuples
@@ -699,16 +865,47 @@ contexts:
       scope: invalid.illegal.expected-comma.python
 
   function-parameter-annotation:
+    - meta_include_prototype: false
     - meta_scope: meta.function.parameters.annotation.python
-    - match: (?=[,)=])
+    - include: line-continuations
+    - match: (?=\S)
+      set: function-parameter-annotation-body
+
+  function-parameter-annotation-body:
+    - meta_scope: meta.function.parameters.annotation.python
+    - meta_content_scope: meta.type.python
+    - match: \s*(?=[,)=])
       set: function-parameter-list-body
-    - match: None\b
-      scope: constant.language.null.python
+    # Scope newline `meta.type` only, if type continues on next line.
+    # Note: This is required to workaround ST's line blindness.
+    - match: (?=\s*\n)
+      branch_point: function-parameter-annotation-end
+      branch:
+        - function-parameter-annotation-continue
+        - function-parameter-annotation-end
+    - include: function-parameter-annotation-content
+
+  function-parameter-annotation-content:
+    # Note: maybe type-hint expressions
+    - include: type-constants
     - include: expression-in-a-group
+
+  function-parameter-annotation-continue:
+    - meta_include_prototype: false
+    - match: \s*(?=[,)=])
+      fail: function-parameter-annotation-end
+    - include: comments
+    - include: else-pop
+
+  function-parameter-annotation-end:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2
+      push: function-parameter-list-body
 
   function-parameter-default-value:
     - meta_scope: meta.function.parameters.default-value.python
-    - match: (?=[,)])
+    - match: (?=[,)=])
       set: function-parameter-list-body
     - include: expression-in-a-group
 
@@ -755,27 +952,45 @@ contexts:
   function-after-parameters:
     - meta_content_scope: meta.function.python
     - match: ->
-      scope: meta.function.annotation.return.python punctuation.separator.annotation.return.python
+      scope: punctuation.separator.return-type.python
       set: function-return-type
     - include: function-definition-end
 
   function-return-type:
-    - meta_content_scope: meta.function.annotation.return.python
-    - include: function-definition-end
+    - meta_include_prototype: false
+    - meta_scope: meta.function.return-type.python
+    - include: line-continuation-or-pop
+    - match: (?=\S)
+      set: function-return-type-body
+
+  function-return-type-body:
+    - meta_content_scope: meta.function.return-type.python meta.type.python
+    - match: (\s*)({{colon}})
+      captures:
+        1: meta.function.return-type.python
+        2: meta.function.python punctuation.section.function.begin.python
+      pop: 1
+    - include: line-continuation-or-pop
+    - include: function-return-type-content
+
+  function-return-type-content:
+    # Note: maybe type-hint expressions
+    - include: illegal-assignment-expressions
+    - include: type-constants
     - include: expression-in-a-statement
 
   function-definition-end:
     - match: '{{colon}}'
       scope: meta.function.python punctuation.section.function.begin.python
       pop: 1
-    - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
+    - include: illegal-assignment-expressions
 
 ###[ ASSIGNMENT STATEMENTS ]##################################################
 
   assignment-statements:
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.variable.python
+      scope: punctuation.separator.annotation.python
       push: variable-annotation
     - match: '{{augmented_assignment_operators}}'
       scope: keyword.operator.assignment.augmented.python
@@ -789,12 +1004,22 @@ contexts:
     - include: expression-in-a-statement
 
   variable-annotation:
-    - meta_scope: meta.variable.annotation.python
-    - match: (?=$|=|#|;)
+    - meta_include_prototype: false
+    - include: line-continuation-or-pop
+    - match: (?=\S)
+      set: variable-annotation-body
+
+  variable-annotation-body:
+    - meta_content_scope: meta.type.python
+    - match: (?=\s*[\n#):;=\]}])
       pop: 1
-    - match: None\b
-      scope: constant.language.null.python
-    - include: expression-in-a-group
+    - include: line-continuations
+    - include: variable-annotation-content
+
+  variable-annotation-content:
+    # Note: maybe type-hint expressions
+    - include: type-constants
+    - include: expression-in-a-statement
 
 ###[ CASE STATEMENTS ]########################################################
 
@@ -1793,7 +2018,7 @@ contexts:
       set: maybe-item-access-body
 
   maybe-item-access-body:
-    - meta_scope: meta.item-access.python
+    - meta_scope: meta.brackets.python
     - match: \]
       scope: punctuation.section.brackets.end.python
       set: after-expression
@@ -1928,7 +2153,7 @@ contexts:
 
   builtin-exceptions:
     - match: '{{builtin_exceptions}}'
-      scope: support.type.exception.python
+      scope: support.class.exception.python
 
   builtin-functions:
     - match: '{{builtin_functions}}'
@@ -1937,6 +2162,8 @@ contexts:
   builtin-types:
     - match: '{{builtin_types}}'
       scope: support.type.python
+    - match: '{{typing_types}}'
+      scope: support.class.typing.python
 
   magic-functions:
     # these methods have magic interpretation by python and are generally called indirectly through syntactic constructs
@@ -3477,13 +3704,17 @@ contexts:
     - match: (?=\S)
       pop: 1
 
+  eol-pop:
+    - match: $
+      pop: 1
+
   immediately-pop:
     - match: ''
       pop: 1
 
   line-continuation-or-pop:
     - include: line-continuations
-    - match: (?=\s*(?:\n|;|#))
+    - match: (?=\s*[\n;#])
       pop: 1
 
   line-continuations:
@@ -3496,5 +3727,6 @@ contexts:
     - meta_include_prototype: false
     # This prevents strings after a continuation from being a docstring
     - include: strings
-    - match: (?=\S|^\s*$|\n)  # '\n' for when we matched a string earlier
+    - include: else-pop
+    - match: ^(?!\s*[[:alpha:]]*['"])
       pop: 1

--- a/syntaxes/pyright.sublime-syntax
+++ b/syntaxes/pyright.sublime-syntax
@@ -13,17 +13,37 @@ file_extensions:
 contexts:
   main:
     - include: lsp-type
-    - include: statements
+    - include: class-definitions
+    - include: function-definitions
+    - include: assignment-statements
+    - include: qualified-name
+    - include: comments
 
 ###[ PYTHON TYPE ANNOTATIONS ]################################################
 
-  function-parameter-annotation:
-    - meta_prepend: true
-    - include: lsp-type-annotations
+  function-parameter-annotation-content:
+    - include: type-hint-expressions
 
-  variable-annotation:
+  function-return-type-content:
+    - include: type-hint-expressions
+
+  variable-annotation-content:
+    - include: type-hint-expressions
+
+  type-hint-expressions:
     - meta_prepend: true
-    - include: lsp-type-annotations
+    - match: (?=\()
+      branch_point: lsp-type-parens
+      branch:
+        - lsp-type-function
+        - lsp-type-group
+
+  type-separators:
+    - meta_prepend: true
+    - match: \@
+      scope: punctuation.accessor.python
+    - match: \|
+      scope: keyword.operator.logical.union.python
 
 ###[ PYRIGHT TYPE TAGS ]######################################################
 
@@ -42,43 +62,37 @@ contexts:
 
 ###[ PYRIGHT TYPE ANNOTATIONS ]###############################################
 
-  lsp-type-annotations:
-    - include: lsp-type-parens
-    - include: lsp-type-signatures
-
-  lsp-type-parens:
-    - match: (?=\()
-      branch_point: lsp-type-parens
-      branch:
-        - lsp-type-function
-        - lsp-type-group
-
   lsp-type-function:
     - match: \(
       scope: meta.function.parameters.python punctuation.section.parameters.begin.python
-      set: lsp-type-function-parameter-list
+      set: lsp-type-function-parameter-list-body
     - include: immediately-pop
 
-  lsp-type-function-parameter-list:
+  lsp-type-function-parameter-list-body:
     - meta_content_scope: meta.function.parameters.python
     - match: \)
       scope: meta.function.parameters.python punctuation.section.parameters.end.python
       set: lsp-type-function-return-type
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.parameter.python
+      scope: punctuation.separator.annotation.python
       set: lsp-type-function-parameter-annotation
     - match: '{{identifier}}(?={{colon}})'
       scope: variable.parameter.python
-    - include: function-parameter-annotation
     - include: lsp-type-parameter-common
+    - include: type-hint-expressions
 
   lsp-type-function-parameter-annotation:
     - meta_scope: meta.function.parameters.annotation.python
-    - match: (?=[,)=])
-      set: lsp-type-function-parameter-list
-    - match: None\b
-      scope: constant.language.null.python
-    - include: expression-in-a-group
+    - include: lsp-type-function-parameter-list-continue
+    - include: line-continuations
+    - match: (?=\S)
+      set: lsp-type-function-parameter-annotation-body
+
+  lsp-type-function-parameter-annotation-body:
+    - meta_scope: meta.function.parameters.annotation.python meta.type.python
+    - include: lsp-type-function-parameter-list-continue
+    - include: line-continuations
+    - include: type-hint-expressions
 
   lsp-type-parameter-common:
     - match: ','
@@ -89,17 +103,41 @@ contexts:
       push: function-parameter-expect-comma
     - match: '{{assignment_operator}}'
       scope: keyword.operator.assignment.python
-      set: function-parameter-default-value
+      set: lsp-type-function-parameter-default-value
     - include: line-continuations
-    - include: illegal-assignment-expressions
+
+  lsp-type-function-parameter-default-value:
+    - meta_scope: meta.function.parameters.default-value.python
+    - include: lsp-type-function-parameter-list-continue
+    - include: expression-in-a-group
+
+  lsp-type-function-parameter-list-continue:
+    - match: (?=[,)=])
+      set: lsp-type-function-parameter-list-body
 
   lsp-type-function-return-type:
     - meta_content_scope: meta.function.python
     - match: ->
-      scope: meta.function.annotation.return.python punctuation.separator.annotation.return.python
-      set: function-return-type
+      scope: punctuation.separator.return-type.python
+      set: lsp-type-function-return-type-begin
     - match: (?=\S)
       fail: lsp-type-parens
+
+  lsp-type-function-return-type-begin:
+    - meta_scope: meta.function.return-type.python
+    - match: (?=\S)
+      set: lsp-type-function-return-type-body
+    - include: eol-pop
+
+  lsp-type-function-return-type-body:
+    - meta_scope: meta.function.return-type.python meta.type.python
+    - include: lsp-type-function-return-type-end
+    - include: type-hint-expressions
+
+  lsp-type-function-return-type-end:
+    - include: line-continuations
+    - match: (?=\s*[\n#),:;=\]}])
+      pop: 1
 
   lsp-type-group:
     - match: \(
@@ -112,27 +150,8 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.python
       set: after-expression
-    - include: lsp-type-annotations
-    - include: expression-in-a-group
-
-  lsp-type-signatures:
-    - match: (?={{path}}\s*\[)
-      push:
-        - lsp-type-list
-        - qualified-name-content
-
-  lsp-type-list:
-    - match: \[
-      scope: punctuation.section.sequence.begin.python
-      set: lsp-type-list-body
-
-  lsp-type-list-body:
-    - meta_scope: meta.sequence.list.python
-    - match: \]
-      scope: punctuation.section.sequence.end.python
-      set: after-expression
-    - include: lsp-type-annotations
-    - include: expression-in-a-group
+    - include: line-continuations
+    - include: type-hint-expressions
 
 ###[ PYTHON CLASS DEFINITION OVERRIDES ]######################################
 
@@ -158,24 +177,31 @@ contexts:
       scope: meta.class.parameters.python punctuation.section.parameters.end.python
       set: after-expression
     - match: '{{colon}}'
-      scope: punctuation.separator.annotation.parameter.python
+      scope: punctuation.separator.annotation.python
       set: class-definition-parameter-annotation
     - include: parameter-names
     - include: lsp-type-parameter-common
 
   class-definition-parameter-annotation:
     - meta_scope: meta.class.parameters.annotation.python
-    - match: (?=[,)=])
-      set: class-definition-base-list-body
-    - match: None\b
-      scope: constant.language.null.python
-    - include: expression-in-a-group
+    - match: (?=\S)
+      set: class-definition-parameter-annotation-body
+
+  class-definition-parameter-annotation-body:
+    - meta_scope: meta.class.parameters.annotation.python
+    - meta_content_scope: meta.type.python
+    - include: class-definition-base-list-continue
+    - include: line-continuations
+    - include: type-hint-expressions
 
   class-definition-parameter-default-value:
     - meta_scope: meta.class.parameters.default-value.python
-    - match: (?=[,)])
-      set: class-definition-base-list-body
+    - include: class-definition-base-list-continue
     - include: expression-in-a-group
+
+  class-definition-base-list-continue:
+    - match: (?=[,)=])
+      set: class-definition-base-list-body
 
 ###[ PYTHON FUNCTION DEFINITION OVERRIDES ]###################################
 
@@ -196,16 +222,14 @@ contexts:
       set: lsp-function-signature
 
   lsp-function-signature:
-    - meta_content_scope: meta.function.annotation.signature.python
-    - include: function-definition-end
-    - include: lsp-type-annotations
-    - include: expression-in-a-statement
+    - meta_content_scope: meta.function.signature.python
+    - match: (?=\S)
+      set: lsp-function-signature-body
 
-  function-definition-end:
-    - meta_prepend: true
-    # additional conditions which terminate a function signature
-    - match: (?=[,)\]])
-      pop: 1
+  lsp-function-signature-body:
+    - meta_content_scope: meta.function.signature.python meta.type.python
+    - include: lsp-type-function-return-type-end
+    - include: type-hint-expressions
 
 ###[ PROTOTYPES ]#############################################################
 

--- a/syntaxes/pyright.sublime-syntax
+++ b/syntaxes/pyright.sublime-syntax
@@ -5,7 +5,7 @@ scope: source.python.lsp
 version: 2
 hidden: true
 
-extends: Packages/Python/Python.sublime-syntax
+extends: Python.sublime-syntax
 
 file_extensions:
   - pyright-syntax-test

--- a/syntaxes/syntax_test.pyright-syntax-test
+++ b/syntaxes/syntax_test.pyright-syntax-test
@@ -13,23 +13,52 @@ class ClassName(foo: int, /, *args: Any, **kwargs: Any)
 #                            ^ keyword.operator.unpacking.sequence
 #                             ^^^^ variable.parameter
 #                                 ^ punctuation.separator.annotation
-#                                   ^^^ meta.generic-name
+#                                   ^^^ support.class
 #                                      ^ punctuation.separator
 #                                        ^^ keyword.operator.unpacking.mapping
 #                                          ^^^^^^ variable.parameter
-#                                                  ^^^ meta.generic-name
+#                                                  ^^^ support.class
 
-(method) def functionName(cls: Type[Self@ParentName], /, key: str, default: Any | None = None) -> Any
-# ^^^^^ storage.type
-#                         ^^^ variable.parameter
-#                                                     ^ storage.modifier.positional-args-only
-#                                                        ^^^ variable.parameter
-#                                                             ^^^ support.type
-#                                                                  ^^^^^^^ variable.parameter
-#                                                                               ^  keyword.operator
-#                                                                                      ^ keyword.operator
-#                                                                                              ^^ punctuation.separator
+(function) def functionName(self: Self@PanelManager) -> (Any | None)
+#                                 ^^^^^^^^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python
+#                                 ^^^^ support.class.typing.python
+#                                     ^ punctuation.accessor.python
+#                                      ^^^^^^^^^^^^ meta.generic-name.python
+#                                                       ^^^^^^^^^^^^ meta.function.return-type.python meta.type.python meta.group.python
+#                                                       ^ punctuation.section.group.begin.python
+#                                                        ^^^ support.class
+#                                                            ^ keyword.operator.logical.union
+#                                                              ^^^^ constant.language.null.python
+#                                                                  ^ punctuation.section.group.end.python
 
+(function) def functionName(cls: Type[Self@ParentName], /, key: str, default: Any | None = None) -> Any
+# <- meta.parens.python punctuation.section.parens.begin.python
+#^^^^^^^^^ meta.parens.python
+#          ^^^^^^^^^^^^^^^^ meta.function.python
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
+#                                                                                               ^ meta.function.python
+#                                                                                                ^^^^^^ meta.function.return-type.python
+#^^^^^^^^ storage.type.python
+#        ^ punctuation.section.parens.end.python
+#                           ^^^ variable.parameter.python
+#                              ^ punctuation.separator.annotation.python
+#                                ^^^^^^^^^^^^^^^^^^^^^ meta.type.python
+#                                                     ^ punctuation.separator.parameters.python
+#                                                       ^ storage.modifier.positional-args-only.python
+#                                                          ^^^ variable.parameter.python
+#                                                               ^^^ meta.type.python support.type.python
+#                                                                  ^ punctuation.separator.parameters.python
+#                                                                    ^^^^^^^ variable.parameter.python
+#                                                                           ^ punctuation.separator.annotation.python
+#                                                                             ^^^^^^^^^^ meta.type.python
+#                                                                             ^^^ support.class.typing.python
+#                                                                                 ^ keyword.operator.logical.union
+#                                                                                   ^^^^ constant.language.null.python
+#                                                                                        ^ keyword.operator.assignment.python
+#                                                                                          ^^^^ constant.language.null.python
+#                                                                                              ^ punctuation.section.parameters.end.python
+#                                                                                                ^^ punctuation.separator.return-type.python
+#                                                                                                   ^^^ support.class.typing.python
 
 (method) def methodName(cls: Type[Self@ParentName], key: str, default: Any | None = None) -> Any
 # ^^^^^ storage.type
@@ -37,15 +66,15 @@ class ClassName(foo: int, /, *args: Any, **kwargs: Any)
 #                                                   ^^^ variable.parameter
 #                                                        ^^^ support.type
 #                                                             ^^^^^^^ variable.parameter
-#                                                                          ^  keyword.operator
+#                                                                          ^ keyword.operator
 #                                                                                 ^ keyword.operator
 #                                                                                         ^^ punctuation.separator
 
 (function) def fail: _WithException[(reason: str = "", pytrace: bool = True, msg: str | None = None) -> NoReturn, Type[Failed]]
 #^^^^^^^^ storage.type.python
 #          ^^^^^^^^^ meta.function.python
-#                    ^^^^^^^^^^^^^^ meta.function.annotation.signature.python - meta.item-access
-#                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.annotation.signature.python meta.sequence.list.python
+#                    ^^^^^^^^^^^^^^ meta.function.signature.python - meta.item-access
+#                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.signature.python meta.brackets.python
 #                                   ^^^^^^^ meta.function.parameters.python
 #                                          ^^^^^^ meta.function.parameters.annotation.python
 #                                                ^^^^ meta.function.parameters.default-value.python
@@ -57,41 +86,40 @@ class ClassName(foo: int, /, *args: Any, **kwargs: Any)
 #                                                                                            ^^^^^^ meta.function.parameters.default-value.python
 #                                                                                                  ^ meta.function.parameters.python
 #                                                                                                   ^ meta.function.python
-#                                                                                                    ^^^^^^^^^^^ meta.function.annotation.return.python
-#                                                                                                                     ^^^^^^^^ meta.sequence.list.python
+#                                                                                                    ^^^^^^^^^^^ meta.function.return-type.python
+#                                                                                                                     ^^^^^^^^ meta.brackets.python
 #          ^^^ keyword.declaration.function.python
 #              ^^^^ entity.name.function.python
 #                    ^^^^^^^^^^^^^^ meta.path.python meta.generic-name.python
-#                                  ^ punctuation.section.sequence.begin.python
+#                                  ^ punctuation.section.brackets.begin.python
 #                                   ^ punctuation.section.parameters.begin.python
 #                                    ^^^^^^ variable.parameter.python
-#                                          ^ punctuation.separator.annotation.parameter.python
-#                                            ^^^ meta.path.python support.type.python
+#                                          ^ punctuation.separator.annotation.python
+#                                            ^^^ support.type.python
 #                                                ^ keyword.operator.assignment.python
 #                                                  ^^ meta.string.python string.quoted.double.python
 #                                                    ^ punctuation.separator.parameters.python
 #                                                      ^^^^^^^ variable.parameter.python
-#                                                             ^ punctuation.separator.annotation.parameter.python
-#                                                               ^^^^ meta.path.python support.type.python
+#                                                             ^ punctuation.separator.annotation.python
+#                                                               ^^^^ support.type.python
 #                                                                    ^ keyword.operator.assignment.python
 #                                                                      ^^^^ constant.language.boolean.python
 #                                                                          ^ punctuation.separator.parameters.python
 #                                                                            ^^^ variable.parameter.python
-#                                                                               ^ punctuation.separator.annotation.parameter.python
-#                                                                                 ^^^ meta.path.python support.type.python
-#                                                                                     ^ keyword.operator.arithmetic.python
+#                                                                               ^ punctuation.separator.annotation.python
+#                                                                                 ^^^ support.type.python
+#                                                                                     ^ keyword.operator.logical.union
 #                                                                                       ^^^^ constant.language.null.python
 #                                                                                            ^ keyword.operator.assignment.python
 #                                                                                              ^^^^ constant.language.null.python
 #                                                                                                  ^ punctuation.section.parameters.end.python
-#                                                                                                    ^^ punctuation.separator.annotation.return.python
-#                                                                                                       ^^^^^^^^ meta.path.python meta.generic-name.python
+#                                                                                                    ^^ punctuation.separator.return-type.python
+#                                                                                                       ^^^^^^^^ support.class.typing.python
 #                                                                                                               ^ punctuation.separator.sequence.python
-#                                                                                                                 ^^^^ meta.path.python meta.generic-name.python
-#                                                                                                                     ^ punctuation.section.sequence.begin.python
+#                                                                                                                 ^^^^ support.class.typing.python
+#                                                                                                                     ^ punctuation.section.brackets.begin.python
 #                                                                                                                      ^^^^^^ meta.path.python meta.generic-name.python
-#                                                                                                                            ^ punctuation.section.sequence.end.python
-#                                                                                                                             ^ punctuation.section.sequence.end.python
+#                                                                                                                            ^^ punctuation.section.brackets.end.python
 #
 
 (variable) variable_name: int
@@ -101,23 +129,53 @@ class ClassName(foo: int, /, *args: Any, **kwargs: Any)
 
 (variable) TemporaryFile: Overload[(mode: Literal['r', 'w'], buffering: int = ...) -> _TemporaryFileWrapper[str]]
 # ^^^^^^^ storage.type
-#          ^^^^^^^^^^^^^ meta.path.python meta.generic-name.python
-#                       ^^^^^^^^^^ meta.variable.annotation.python
-#                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.variable.annotation.python meta.sequence.list.python
-#                       ^ punctuation.separator.annotation.variable.python
-#                         ^^^^^^^^ meta.path.python meta.generic-name.python
-#                                 ^ punctuation.section.sequence.begin
-#                                   ^^^^ variable.parameter
-#                                                 ^^^ string.quoted.single
-#                                                            ^^^^^^^^^ variable.parameter
-#                                                                           ^ keyword.operator
+#          ^^^^^^^^^^^^^ meta.generic-name.python
+#                         ^^^^^^^^ meta.type.python
+#                                 ^ meta.type.python meta.brackets.python - meta.function
+#                                  ^^^^^ meta.type.python meta.brackets.python meta.function.parameters.python
+#                                       ^^ meta.type.python meta.brackets.python meta.function.parameters.annotation.python - meta.type meta.type
+#                                         ^^^^^^^^^^^^^^^^^ meta.type.python meta.function.parameters.annotation.python meta.type.python
+#                                                          ^^^^^^^^^^^ meta.type.python meta.brackets.python meta.function.parameters - meta.type meta.type
+#                                                                     ^ meta.type.python meta.brackets.python meta.function.parameters.annotation.python punctuation.separator.annotation.python
+#                                                                      ^ meta.type.python meta.brackets.python meta.function.parameters.annotation.python
+#                                                                       ^^^^ meta.type.python meta.brackets.python meta.function.parameters.annotation.python meta.type.python
+#                                                                           ^^^^^ meta.type.python meta.brackets.python meta.function.parameters.default-value.python
+#                                                                                ^ meta.type.python meta.brackets.python meta.function.parameters.python
+#                                                                                 ^ meta.type.python meta.brackets.python meta.function.python
+#                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.python meta.brackets.python meta.function.return-type.python
+#                                                                                                               ^ meta.type.python meta.brackets.python - meta.function
+#                       ^ punctuation.separator.annotation.python
+#                         ^^^^^^^^ meta.generic-name.python
+#                                 ^ punctuation.section.brackets.begin.python
+#                                   ^^^^ variable.parameter.python
+#                                       ^ punctuation.separator.annotation.python
+#                                         ^^^^^^^ support.class.typing.python
+#                                                ^^^^^^^^^^ meta.brackets.python meta.brackets.python
+#                                                ^ punctuation.section.brackets.begin.python
+#                                                 ^^^ string.quoted.single.python
+#                                                    ^ punctuation.separator.sequence.python
+#                                                      ^^^ string.quoted.single.python
+#                                                         ^ punctuation.section.brackets.end.python
+#                                                          ^ punctuation.separator.parameters.python
+#                                                            ^^^^^^^^^ variable.parameter.python
+#                                                                     ^ punctuation.separator.annotation.python
+#                                                                       ^^^ support.type.python
+#                                                                           ^ keyword.operator.assignment.python
+#                                                                             ^^^ constant.language.python
+#                                                                                ^ punctuation.section.parameters.end.python
 #                                                                                  ^^ punctuation.separator
-#                                                                                                               ^ punctuation.section.sequence.end
+#                                                                                     ^^^^^^^^^^^^^^^^^^^^^ meta.generic-name.python
+#                                                                                                          ^^^^^ meta.brackets.python meta.brackets.python
+#                                                                                                          ^ punctuation.section.brackets.begin.python
+#                                                                                                           ^^^ support.type.python
+#                                                                                                              ^^ punctuation.section.brackets.end.python
 
-import os, tempfile
-if os.name != "nt":
-    f = tempfile.NamedTemporaryFile("w")
-# The following case comes  the above code when running under Windows and hover on "NamedTemporaryFile".
+# ```py
+# import os, tempfile
+# if os.name != "nt":
+#     f = tempfile.NamedTemporaryFile("w")
+# ```
+# The following case comes the above code when running under Windows and hover on "NamedTemporaryFile".
 # Notice that it has no leading type information, e.g., "(variable)".
 NamedTemporaryFile: Overload[() -> None, () -> None, (mode: Literal['r', 'w'] = ..., size: int = ...) -> None]
 #                                                     ^^^^ variable.parameter
@@ -127,56 +185,61 @@ NamedTemporaryFile: Overload[() -> None, () -> None, (mode: Literal['r', 'w'] = 
 
 def foo(callback: ((arg: _T@foo) -> bool) | ((_T@foo) -> int) | None = None) -> (_T@foo | None)
 #       ^^^^^^^^ meta.function.parameters.python
-#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.annotation.python
+#               ^^ meta.function.parameters.annotation.python - meta.type
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.annotation.python meta.type.python
+#                                                                   ^ meta.function.parameters.annotation.python - meta.type
+#                                                                    ^^^^^^ meta.function.parameters.default-value.python
+#                                                                          ^ meta.function.parameters.python
 #                 ^ meta.group.python - meta.group meta.function
 #                  ^^^^ meta.group.python meta.function.parameters.python
-#                      ^^^^^^^^ meta.group.python meta.function.parameters.annotation.python
+#                      ^^ meta.group.python meta.function.parameters.annotation.python - meta.type meta.type
+#                        ^^^^^^ meta.group.python meta.function.parameters.annotation.python meta.type.python
 #                              ^ meta.group.python meta.function.parameters.python
 #                               ^ meta.group.python meta.function.python
-#                                ^^^^^^^ meta.group.python meta.function.annotation.return.python
-#                                       ^ meta.group.python -  meta.group meta.function
+#                                ^^^^^^^ meta.group.python meta.function.return-type.python
+#                                       ^ meta.group.python - meta.group meta.function
 #                                           ^ meta.group.python - meta.group meta.function
 #                                            ^^^^^^^^ meta.group.python meta.function.parameters.python
 #                                                    ^ meta.group.python meta.function.python
-#                                                     ^^^^^^ meta.group.python meta.function.annotation.return.python
+#                                                     ^^^^^^ meta.group.python meta.function.return-type.python
 #                                                           ^ meta.group.python - meta.group meta.function
 #                                                                    ^^^^^^ meta.function.parameters.default-value.python
 #                                                                          ^ meta.function.parameters.python
 #                                                                           ^ meta.function.python
-#                                                                            ^^^ meta.function.annotation.return.python - meta.group
-#                                                                               ^^^^^^^^^^^^^^^ meta.function.annotation.return.python meta.group.python
-#               ^ punctuation.separator.annotation.parameter.python
+#                                                                            ^^^ meta.function.return-type.python - meta.group
+#                                                                               ^^^^^^^^^^^^^^^ meta.function.return-type.python meta.group.python
+#               ^ punctuation.separator.annotation.python
 #                 ^ punctuation.section.group.begin.python
 #                  ^ punctuation.section.parameters.begin.python
 #                   ^^^ variable.parameter.python
-#                      ^ punctuation.separator.annotation.parameter.python
+#                      ^ punctuation.separator.annotation.python
 #                        ^^ meta.path.python meta.generic-name.python
-#                          ^ keyword.operator.arithmetic.python
+#                          ^ punctuation.accessor.python
 #                           ^^^ meta.path.python meta.generic-name.python
 #                              ^ punctuation.section.parameters.end.python
-#                                ^^ punctuation.separator.annotation.return.python
-#                                   ^^^^ meta.path.python support.type.python
+#                                ^^ punctuation.separator.return-type.python
+#                                   ^^^^ support.type.python
 #                                       ^ punctuation.section.group.end.python
-#                                         ^ keyword.operator.arithmetic.python
+#                                         ^ keyword.operator.logical.union
 #                                           ^ punctuation.section.group.begin.python
 #                                            ^ punctuation.section.parameters.begin.python
 #                                             ^^ meta.path.python meta.generic-name.python
-#                                               ^ keyword.operator.arithmetic.python
+#                                               ^ punctuation.accessor.python
 #                                                ^^^ meta.path.python meta.generic-name.python
 #                                                   ^ punctuation.section.parameters.end.python
-#                                                     ^^ punctuation.separator.annotation.return.python
-#                                                        ^^^ meta.path.python support.type.python
+#                                                     ^^ punctuation.separator.return-type.python
+#                                                        ^^^ support.type.python
 #                                                           ^ punctuation.section.group.end.python
-#                                                             ^ keyword.operator.arithmetic.python
+#                                                             ^ keyword.operator.logical.union
 #                                                               ^^^^ constant.language.null.python
 #                                                                    ^ keyword.operator.assignment.python
 #                                                                      ^^^^ constant.language.null.python
 #                                                                          ^ punctuation.section.parameters.end.python
-#                                                                            ^^ punctuation.separator.annotation.return.python
+#                                                                            ^^ punctuation.separator.return-type.python
 #                                                                               ^ punctuation.section.group.begin.python
 #                                                                                ^^ meta.path.python meta.generic-name.python
-#                                                                                  ^ keyword.operator.arithmetic.python
+#                                                                                  ^ punctuation.accessor.python
 #                                                                                   ^^^ meta.path.python meta.generic-name.python
-#                                                                                       ^ keyword.operator.arithmetic.python
+#                                                                                       ^ keyword.operator.logical.union
 #                                                                                         ^^^^ constant.language.null.python
 #                                                                                             ^ punctuation.section.group.end.python


### PR DESCRIPTION
This PR provides required adjustments for pyright's syntax to work with https://github.com/sublimehq/Packages/pull/3736.

Unfortunately some of mensioned PRs changes break current syntax and I found no sane way around it.

