### PR TITLE
Replace black with ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,17 @@ all:
 .PHONY: ci-check
 ci-check:
  	# mypy -p plugin
-	echo "Linting: ruff..."
+	echo "Check: ruff (lint)"
 	ruff check --diff --preview .
-	echo "Linting: black..."
-	black --diff --preview --check .
+	echo "Check: ruff (format)"
+	ruff format --diff --preview .
 
 .PHONY: ci-fix
 ci-fix:
-	echo "Fixing: ruff..."
+	echo "Fix: ruff (lint)"
 	ruff check --preview --fix .
-	# ruff format --preview .
-	echo "Fixing: black..."
-	black --preview .
-
+	echo "Fix: ruff (format)"
+	ruff format --preview .
 
 .PHONY: update-schema
 update-schema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,18 @@
-[tool.black]
-preview = true # use latest feature
-line-length = 120
-target-version = ['py38']
-exclude = '''
-/(
-  \.git |
-  \.venv(-.*)? |
-  language-server |
-  plugin/libs |
-  resources |
-  stubs |
-  typings |
-  _resources
-)/
-'''
-
 [tool.pyright]
 pythonVersion = '3.11'
 
 [tool.ruff]
 preview = true
-select = ["E", "F", "W", "I"]
-ignore = [
-  "E203",
-  "F401", # we still need to use type annotation in comments in py33
-]
 line-length = 120
 target-version = 'py38'
 exclude = [
+  "*/libs/*",
   ".git",
   ".mypy_cache",
   ".venv",
   ".venv-*",
   "branch-*",
-  "libs",
-  "plugin/libs",
+  "scripts/module_scraper",
   "stubs",
   "tests/files",
   "typings",
@@ -42,3 +20,13 @@ exclude = [
   "venv",
   "venv-*",
 ]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"] # no "UP" because actually running py33
+ignore =  [
+  "E203",
+  "F401", # we still need to use type annotation in comments in py33
+]
+
+[tool.ruff.lint.per-file-ignores]
+"boot.py" = ["E402"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # This is an implicit value, here for clarity
 --index https://pypi.python.org/simple/
 
-black
 mypy
-ruff
+ruff>=0.2

--- a/scripts/update_schema.py
+++ b/scripts/update_schema.py
@@ -11,7 +11,9 @@ PACKAGE_NAME = "LSP-pyright"
 
 PROJECT_ROOT = Path(__file__).parents[1]
 PYRIGHTCONFIG_SCHEMA_ID = "sublime://pyrightconfig"
-PYRIGHT_CONFIGURATION_SCHEMA_URL = "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"  # noqa: E501
+PYRIGHT_CONFIGURATION_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"  # noqa: E501
+)
 SUBLIME_PACKAGE_JSON_PATH = PROJECT_ROOT / "sublime-package.json"
 # Keys that are in the pyrightconfig.json schema but should not raise a comment when not present in the LSP schema.
 IGNORED_PYRIGHTCONFIG_KEYS = {


### PR DESCRIPTION
`ruff` reaches v0.2.0 today with some config renamed.
https://github.com/astral-sh/ruff/releases/tag/v0.2.0

This PR replaces `black` (code formatter) with `ruff` to reduce numerbs of dependency and improve CI performance.
