### PR TITLE
Add settings for disableTaggedHints

### DIFF
--- a/LSP-pyright.sublime-settings
+++ b/LSP-pyright.sublime-settings
@@ -78,6 +78,8 @@
 		"pyright.disableLanguageServices": false,
 		// Disables the "Organize Imports" command.
 		"pyright.disableOrganizeImports": false,
+		// Disables the use of hint diagnostics with special tags.
+		"pyright.disableTaggedHints": false,
 		// Path to Python. Leave empty to attempt automatic resolution.
 		"python.pythonPath": "",
 		// Path to folder with a list of Virtual Environments.

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -61,6 +61,11 @@
                       "description": "Disables the \"Organize Imports\" command.",
                       "type": "boolean"
                     },
+                    "pyright.disableTaggedHints": {
+                      "default": false,
+                      "description": "Disables the use of hint diagnostics with special tags",
+                      "type": "boolean"
+                    },
                     "python.analysis.autoImportCompletions": {
                       "default": true,
                       "description": "Offer auto-import completions.",


### PR DESCRIPTION
This adds `pyright.disableTaggedHints` to the settings. Users can configure the setting in Sublime Text as follows:

```json
{
    "settings": {
        "pyright.disableTaggedHints": true,
    }
}
```

This works in the current version of LSP-pyright in Sublime Text but it's not listed in the default settings as an option. So this pull request adds it as an option.