### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from .client import LspPyrightPlugin, ViewEventListener
-from .commands import LspPyrightCreateConfigurationCommand, LspPyrightUpdateViewStatusTextCommand
+from .client import LspPyrightPlugin
+from .client import ViewEventListener
+from .commands import LspPyrightCreateConfigurationCommand
+from .commands import LspPyrightUpdateViewStatusTextCommand
 
 __all__ = (
     # ST: core

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -1,26 +1,35 @@
 from __future__ import annotations
 
+from .constants import PACKAGE_NAME
+from .constants import SERVER_SETTING_DEV_ENVIRONMENT
+from .dev_environment.helpers import get_dev_environment_handler
+from .log import log_error
+from .log import log_warning
+from .utils_lsp import find_workspace_folder
+from .utils_lsp import uri_to_file_path
+from .utils_lsp import WorkspaceFolderAttr
+from .virtual_env.helpers import find_venv_by_finder_names
+from collections import defaultdict
+from LSP.plugin import ClientConfig
+from LSP.plugin import DottedDict
+from LSP.plugin import MarkdownLangMap
+from LSP.plugin import Response
+from LSP.protocol import CompletionItem
+from LSP.protocol import Hover
+from LSP.protocol import SignatureHelp
+from lsp_utils import NpmClientHandler
+from pathlib import Path
+from sublime_lib import ResourcePath
+from typing import Any
+from typing import cast
+from typing import final
+from typing_extensions import override
+import jmespath
 import json
 import os
 import re
-from collections import defaultdict
-from pathlib import Path
-from typing import Any, cast, final
-
-import jmespath
 import sublime
 import sublime_plugin
-from LSP.plugin import ClientConfig, DottedDict, MarkdownLangMap, Response
-from LSP.protocol import CompletionItem, Hover, SignatureHelp
-from lsp_utils import NpmClientHandler
-from sublime_lib import ResourcePath
-from typing_extensions import override
-
-from .constants import PACKAGE_NAME, SERVER_SETTING_DEV_ENVIRONMENT
-from .dev_environment.helpers import get_dev_environment_handler
-from .log import log_error, log_warning
-from .utils_lsp import WorkspaceFolderAttr, find_workspace_folder, uri_to_file_path
-from .virtual_env.helpers import find_venv_by_finder_names
 
 
 class ViewEventListener(sublime_plugin.ViewEventListener):

--- a/plugin/commands/lsp_pyright_create_configuration.py
+++ b/plugin/commands/lsp_pyright_create_configuration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-
 import sublime
 import sublime_plugin
 

--- a/plugin/commands/lsp_pyright_update_status_text.py
+++ b/plugin/commands/lsp_pyright_update_status_text.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, final
-
-import sublime
-from LSP.plugin import LspTextCommand
-from typing_extensions import override
-
 from ..client import LspPyrightPlugin
 from ..constants import PACKAGE_NAME
 from ..log import log_warning
 from ..template import load_string_template
 from ..utils_lsp import find_workspace_folder
+from LSP.plugin import LspTextCommand
+from typing import Any
+from typing import final
+from typing_extensions import override
+import sublime
 
 
 @final

--- a/plugin/dev_environment/helpers.py
+++ b/plugin/dev_environment/helpers.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Generator, Sequence
-
-from more_itertools import first_true
-
-from .impl import (
-    VERSIONED_SUBLIME_TEXT_DEV_ENVIRONMENT_HANDLERS,
-    BlenderDevEnvironmentHandler,
-    GdbDevEnvironmentHandler,
-    SublimeTextDevEnvironmentHandler,
-)
+from .impl import BlenderDevEnvironmentHandler
+from .impl import GdbDevEnvironmentHandler
+from .impl import SublimeTextDevEnvironmentHandler
+from .impl import VERSIONED_SUBLIME_TEXT_DEV_ENVIRONMENT_HANDLERS
 from .interfaces import BaseDevEnvironmentHandler
+from more_itertools import first_true
+from pathlib import Path
+from typing import Generator
+from typing import Sequence
 
 
 def find_dev_environment_handler_class(dev_environment: str) -> type[BaseDevEnvironmentHandler] | None:

--- a/plugin/dev_environment/impl/__init__.py
+++ b/plugin/dev_environment/impl/__init__.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from .blender import BlenderDevEnvironmentHandler
 from .gdb import GdbDevEnvironmentHandler
-from .sublime_text import VERSIONED_SUBLIME_TEXT_DEV_ENVIRONMENT_HANDLERS, SublimeTextDevEnvironmentHandler
+from .sublime_text import SublimeTextDevEnvironmentHandler
+from .sublime_text import VERSIONED_SUBLIME_TEXT_DEV_ENVIRONMENT_HANDLERS
 
 __all__ = (
     "BlenderDevEnvironmentHandler",

--- a/plugin/dev_environment/impl/blender.py
+++ b/plugin/dev_environment/impl/blender.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import json
-import tempfile
-from pathlib import Path
-
-from LSP.plugin.core.collections import DottedDict
-
 from ...utils import run_shell_command
 from ..interfaces import BaseDevEnvironmentHandler
+from LSP.plugin.core.collections import DottedDict
+from pathlib import Path
+import json
+import tempfile
 
 
 class BlenderDevEnvironmentHandler(BaseDevEnvironmentHandler):

--- a/plugin/dev_environment/impl/gdb.py
+++ b/plugin/dev_environment/impl/gdb.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import json
-import tempfile
-from pathlib import Path
-
-from LSP.plugin.core.collections import DottedDict
-
 from ...utils import run_shell_command
 from ..interfaces import BaseDevEnvironmentHandler
+from LSP.plugin.core.collections import DottedDict
+from pathlib import Path
+import json
+import tempfile
 
 
 class GdbDevEnvironmentHandler(BaseDevEnvironmentHandler):

--- a/plugin/dev_environment/impl/sublime_text.py
+++ b/plugin/dev_environment/impl/sublime_text.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-import inspect
-import os
-import re
-import sys
-from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Generator, Tuple, TypeVar
-
-import sublime
+from ..interfaces import BaseDevEnvironmentHandler
+from abc import ABC
+from abc import abstractmethod
 from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.constants import ST_VERSION
 from more_itertools import first_true
+from pathlib import Path
+from typing import Generator
+from typing import Tuple
+from typing import TypeVar
 from typing_extensions import TypeAlias
-
-from ..interfaces import BaseDevEnvironmentHandler
+import inspect
+import os
+import re
+import sublime
+import sys
 
 T = TypeVar("T")
 

--- a/plugin/dev_environment/interfaces.py
+++ b/plugin/dev_environment/interfaces.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Any, Iterable, Literal, Sequence, final
-
+from ..constants import SERVER_SETTING_ANALYSIS_EXTRAPATHS
+from ..constants import SERVER_SETTING_DEV_ENVIRONMENT
+from ..log import log_debug
+from abc import ABC
+from abc import abstractmethod
 from LSP.plugin.core.collections import DottedDict
 from more_itertools import unique_everseen
-
-from ..constants import SERVER_SETTING_ANALYSIS_EXTRAPATHS, SERVER_SETTING_DEV_ENVIRONMENT
-from ..log import log_debug
+from pathlib import Path
+from typing import Any
+from typing import final
+from typing import Iterable
+from typing import Literal
+from typing import Sequence
 
 
 class BaseDevEnvironmentHandler(ABC):

--- a/plugin/log.py
+++ b/plugin/log.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
-
-import sublime
-
 from .constants import PACKAGE_NAME
+from typing import Any
+import sublime
 
 
 def log_debug(message: str) -> None:

--- a/plugin/template.py
+++ b/plugin/template.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
+from .constants import PACKAGE_NAME
 from functools import lru_cache
-
 import jinja2
 import sublime
-
-from .constants import PACKAGE_NAME
 
 JINJA_TEMPLATE_ENV = jinja2.Environment(
     extensions=[

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from .log import log_error
+from collections.abc import Generator
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+from typing import Sequence
+from typing import TypeVar
 import io
 import os
 import re
 import subprocess
 import sys
-from collections.abc import Generator, Iterable
-from pathlib import Path
-from typing import Any, Sequence, TypeVar
-
-from .log import log_error
 
 _T = TypeVar("_T")
 

--- a/plugin/utils_lsp.py
+++ b/plugin/utils_lsp.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
-
-import sublime
-from LSP.plugin import parse_uri
-
-from .utils import drop_falsy, resolved_posix_path
+from .utils import drop_falsy
+from .utils import resolved_posix_path
 from .virtual_env.venv_info import BaseVenvInfo
+from dataclasses import dataclass
+from LSP.plugin import parse_uri
+from pathlib import Path
+import sublime
 
 
 @dataclass

--- a/plugin/virtual_env/helpers.py
+++ b/plugin/virtual_env/helpers.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Sequence
-
+from .venv_finder import find_finder_class_by_name
+from .venv_info import BaseVenvInfo
+from .venv_info import list_venv_info_classes
 from LSP.plugin import Session
 from more_itertools import first_true
-
-from .venv_finder import find_finder_class_by_name
-from .venv_info import BaseVenvInfo, list_venv_info_classes
+from pathlib import Path
+from typing import Sequence
 
 
 def find_venv_by_finder_names(

--- a/plugin/virtual_env/venv_finder.py
+++ b/plugin/virtual_env/venv_finder.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
-import os
-import shutil
-from abc import ABC, abstractmethod
+from ..utils import camel_to_snake
+from ..utils import iterate_lines
+from ..utils import remove_suffix
+from ..utils import run_shell_command
+from .venv_info import BaseVenvInfo
+from .venv_info import CondaVenvInfo
+from .venv_info import list_venv_info_classes
+from .venv_info import Pep405VenvInfo
+from abc import ABC
+from abc import abstractmethod
 from functools import lru_cache
 from itertools import product
-from pathlib import Path
-from types import MappingProxyType
-from typing import Generator, Mapping, final
-
 from LSP.plugin import Session
 from more_itertools import first_true
-
-from ..utils import camel_to_snake, iterate_lines, remove_suffix, run_shell_command
-from .venv_info import BaseVenvInfo, CondaVenvInfo, Pep405VenvInfo, list_venv_info_classes
+from pathlib import Path
+from types import MappingProxyType
+from typing import final
+from typing import Generator
+from typing import Mapping
+import os
+import shutil
 
 
 @lru_cache

--- a/plugin/virtual_env/venv_info.py
+++ b/plugin/virtual_env/venv_info.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+from ..utils import run_shell_command
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+from typing import final
+from typing import Generator
+from typing import TypedDict
+from typing_extensions import Self
 import configparser
 import json
 import os
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Generator, TypedDict, final
-
-from typing_extensions import Self
-
-from ..utils import run_shell_command
 
 
 def list_venv_info_classes() -> Generator[type[BaseVenvInfo], None, None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,8 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "FURB", "SIM", "F401"]
+select = ["E", "F", "W", "I", "UP", "FURB", "SIM"]
 ignore = ["E203"]
-preview = true
 
 [tool.ruff.lint.per-file-ignores]
 "boot.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,17 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "FURB", "SIM"]
+select = ["E", "F", "W", "I", "UP", "FURB", "SIM", "F401"]
 ignore = ["E203"]
+preview = true
 
 [tool.ruff.lint.per-file-ignores]
 "boot.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]

--- a/scripts/update_schema.py
+++ b/scripts/update_schema.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
 from urllib.request import urlopen
+import json
 
 PACKAGE_NAME = "LSP-pyright"
 


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)